### PR TITLE
Remove gulp-util usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ gulp.src('script/*.js')
     .pipe(wrapper({ header: function(file){ return '/* '+ file.path +' MyCompany 2014*/'; } }))
 ```
 
-</br>
+<br>
 ####options.footer
 Type: `string` or `function`
 

--- a/index.js
+++ b/index.js
@@ -6,9 +6,8 @@
 
 
 var through2    = require('through2'),
-    gutil       = require('gulp-util');
-var PluginError = gutil.PluginError;
-
+ PluginError    = require('plugin-error'),
+    path        = require('path');
 
 module.exports = function(opt) {
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(opt) {
       }
 
         //  get the file's name
-    var fileName = file.path.replace(file.base, ''),  //  replace front slash from windowsLand
+    var fileName = path.relative(file.base, file.path),  //  replace front slash from windowsLand
         //  set the new contents
         newContentString = file.contents.toString(),
         header,

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = function(opt) {
     newContentString = header + newContentString + footer;
 
     //  change the file contents
-    file.contents = new Buffer(newContentString);
+    file.contents = Buffer.from(newContentString);
 
     //  push the file into the output
     this.push(file);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "^3.0.4",
-    "through2": "^0.6.5"
+    "through2": "^4.0.2",
+    "plugin-error": "^1.0.1",
+    "vinyl": "^2.2.1"
   },
   "devDependencies": {
     "eslint": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "vinyl": "^2.2.1"
   },
   "devDependencies": {
-    "eslint": "^0.21.0",
-    "mocha": "^2.2.5",
-    "should": "^6.0.1"
+    "eslint": "^8.4.1",
+    "mocha": "^9.1.3",
+    "should": "^13.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-wrapper",
-  "version": "1.0.0",
+  "version": "1.0.0+vasilyevd.1",
   "description": "A gulp plugin for wrapping files with custom strings. Access to filename is given through interpolation.",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AntouanK/gulp-wrapper.git"
+    "url": "https://github.com/vasilyevd/gulp-wrapper.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/main.js
+++ b/test/main.js
@@ -1,12 +1,13 @@
 var should = require('should'),
     wrapper = require('../'),
-    gutil = require('gulp-util'),
-    fs = require('fs'),
-    pj = require('path').join;
+	vinyl = require('vinyl'),
+	fs = require('fs'),
+	pj = require('path').join;
+
+var $filePath = 'test/fixture/file.js';
 
 var getFakeFile = function (fileContent){
-
-	return new gutil.File({
+	return new vinyl({
 		path: './test/fixture/file.js',
 		cwd: './test/',
 		base: './test/fixture/',
@@ -63,7 +64,7 @@ describe('gulp-wrapper', function () {
 				should.exist(file.relative);
 				should.exist(file.contents);
 
-				file.path.should.equal('./test/fixture/file.js');
+				file.path.should.equal($filePath);
 				file.relative.should.equal('file.js');
 				file.contents.toString().should.equal(fakeContent);
 
@@ -93,7 +94,7 @@ describe('gulp-wrapper', function () {
 				should.exist(file.relative);
 				should.exist(file.contents);
 
-				file.path.should.equal('./test/fixture/file.js');
+				file.path.should.equal($filePath);
 				file.relative.should.equal('file.js');
 				file.contents.toString().should.equal(header + fakeContent);
 
@@ -123,7 +124,7 @@ describe('gulp-wrapper', function () {
 				should.exist(file.relative);
 				should.exist(file.contents);
 
-				file.path.should.equal('./test/fixture/file.js');
+				file.path.should.equal($filePath);
 				file.relative.should.equal('file.js');
 				file.contents.toString().should.equal(fakeContent + footer);
 
@@ -155,7 +156,7 @@ describe('gulp-wrapper', function () {
 				should.exist(file.relative);
 				should.exist(file.contents);
 
-				file.path.should.equal('./test/fixture/file.js');
+				file.path.should.equal($filePath);
 				file.relative.should.equal('file.js');
 				file.contents.toString().should.equal(header + fakeContent + footer);
 
@@ -187,7 +188,7 @@ describe('gulp-wrapper', function () {
 				should.exist(file.relative);
 				should.exist(file.contents);
 
-				file.path.should.equal('./test/fixture/file.js');
+				file.path.should.equal($filePath);
 				file.relative.should.equal('file.js');
 				file.contents.toString().should.equal('<script id="'+file.relative+'">' + fakeContent + footer);
 
@@ -220,7 +221,7 @@ describe('gulp-wrapper', function () {
 				should.exist(file.relative);
 				should.exist(file.contents);
 
-				file.path.should.equal('./test/fixture/file.js');
+				file.path.should.equal($filePath);
 				file.relative.should.equal('file.js');
 				file.contents.toString().should.equal(file.path + fakeContent + file.path);
 			});

--- a/test/main.js
+++ b/test/main.js
@@ -11,7 +11,7 @@ var getFakeFile = function (fileContent){
 		path: './test/fixture/file.js',
 		cwd: './test/',
 		base: './test/fixture/',
-		contents: new Buffer(fileContent || '')
+		contents: Buffer.from(fileContent || '')
 	});
 };
 


### PR DESCRIPTION
Migrate away from gulp-util.

1. [plugin-error](https://www.npmjs.com/package/plugin-error) replaced `gulp-util.PluginError`
2. [vinyl](https://www.npmjs.com/package/vinyl) replaced `gulp-util.File`